### PR TITLE
docs: add explainers for AI onboarding and QGIS integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Agent Guidelines for Pyromb
+
+Welcome! When updating this repository, please review the explainer documents before making large changes:
+
+* `documentation/explainers/overview.md` – architecture and data flow summary.
+* `documentation/explainers/qgis_integration_plan.md` – QGIS Processing integration scope and dependency expectations.
+* `documentation/explainers/ai_playbook.md` – contribution workflow and testing guardrails for AI assistants.
+
+These explainers provide the context expected by the maintainers. Update them whenever the architecture or integration plan evolves.
+
+When adding new explainer-style documentation, keep it in `documentation/explainers/` unless maintainers request another location.

--- a/documentation/explainers/ai_playbook.md
+++ b/documentation/explainers/ai_playbook.md
@@ -1,0 +1,28 @@
+# AI Contributor Playbook
+
+Use this playbook when applying AI-assisted development to Pyromb. It distils the key conventions, guardrails, and exploratory steps that have helped previous iterations succeed.
+
+## Before writing code
+
+1. **Understand the target module** – Read the relevant files under `src/pyromb` (especially the `core` package) before proposing changes. The architecture overview in this folder explains the data flow and should be revisited when planning large updates.
+2. **Confirm geometry expectations** – All geometry work happens through the abstractions in `core/geometry`. Avoid introducing new geometry libraries; reuse the existing point/line/polygon classes or extend them cautiously.
+3. **Check dependency rules** – QGIS deployments expect only standard library, NumPy, and GDAL/OGR dependencies. If a feature appears to require Shapely or other heavy GIS libraries, reconsider the approach or design a fallback that uses native QGIS geometry APIs.
+4. **Plan for serialisation** – Any new attributes that affect the output vector files must propagate through `Builder`, `Catchment`, and the relevant `model` writer. Sketch the end-to-end data path before coding to avoid partial integrations.
+
+## During implementation
+
+* **Reuse builders and validators** – Keep shapefile parsing inside the builder. If you need additional validation rules, add them to `core/geometry/shapefile_validation.py` so they apply consistently across entry points.
+* **Maintain tolerance handling** – When matching coordinates, continue to use tolerance-based comparisons. If more precision is necessary, introduce configurable parameters rather than hard-coded thresholds.
+* **Instrument with logging** – Use the `logging` module for standalone scripts and prepare to swap in QGIS `feedback` hooks when integrating into Processing. Avoid print statements.
+
+## Testing strategy
+
+1. **Unit coverage** – Prioritise pure Python units (geometry, maths, model writers) because they run reliably in CI and do not require QGIS.
+2. **Integration checks** – For geometry or builder changes, run the helper script (`python -m src.app`) against the sample data in the `data` directory to confirm end-to-end output remains valid.
+3. **Regression artefacts** – Use the serialisation helpers in `serialise.py` to capture JSON or CSV snapshots of intermediate structures when diagnosing behaviour differences between QGIS and standalone runs.
+
+## Follow-up questions to resolve
+
+* Do we need a dedicated fixture generation script to refresh sample shapefiles for new test cases?
+* Should tolerance thresholds become part of a configuration file so they can be tuned per project?
+* Would a lightweight CLI wrapper around the builder be useful for non-QGIS environments once the Processing integration is complete?

--- a/documentation/explainers/change_review.md
+++ b/documentation/explainers/change_review.md
@@ -1,0 +1,22 @@
+# Review: docs commit vs previous fork state
+
+This note compares commit `8725355` (current `work` branch head) against the prior fork state at `c547d9e`.
+
+## Summary of differences
+
+* Adds three explainer documents (`overview.md`, `qgis_integration_plan.md`, `ai_playbook.md`) under `documentation/explainers/`.
+* No Python package code, tests, or packaging files changed between the two commits.
+
+## Accuracy and completeness observations
+
+* The architecture overview correctly names the core entry points (`src/app.py`, `pyromb.Builder`, `Catchment`, `Traveller`) present in the repository.
+* The QGIS integration plan notes the absence of Shapely and aligns with the dependency list declared in `pyproject.toml`.
+* The AI playbook references testing helpers and pending questions consistent with repository structure.
+
+## Suggested follow-ups
+
+1. Keep the new explainers updated alongside future code changes so they remain trustworthy context for contributors.
+2. Ensure future Processing-algorithm tasks reconcile with the dependency guidance—avoid adding non-native libraries unless QGIS bundles them.
+3. Consider expanding the AI playbook with explicit guidelines for geometry tolerance changes once the QGIS integration amendments begin.
+
+No regressions were detected in this comparison because only documentation files were added.

--- a/documentation/explainers/overview.md
+++ b/documentation/explainers/overview.md
@@ -1,0 +1,25 @@
+# Pyromb Architecture Overview
+
+This explainer summarises how the Pyromb library organises its logic so that AI-assisted contributors can quickly locate the right components.
+
+## High-level package structure
+
+Pyromb exposes a builder-style API for turning GIS vector layers into hydrologic model control files. The key entry point used by the command-line helper script is `src/app.py`, which orchestrates shapefile ingestion, catchment assembly, and file serialisation. It instantiates vector layer wrappers, builds model components with `pyromb.Builder`, connects them into a `Catchment`, then produces the RORB or WBNM text output via a `Traveller`. The helper also supports optional plotting and serialisation for regression testing. `src/app_testing.py` mirrors this workflow with different defaults for test automation, while `serialise.py` and `plot_catchment.py` contain supporting utilities for debugging and visualisation.
+
+Inside the Python package (`src/pyromb`), functionality is grouped into four domains:
+
+* `core`: domain models and algorithms for catchment construction, traversal, and validation. This includes attribute classes (basins, reaches, confluences), geometry abstractions that wrap raw coordinates, and the `Catchment` and `Traveller` classes that connect everything into incidence matrices and model-specific exports.
+* `math`: hydrologic calculations (e.g. loss models) that are used during serialisation of the output control files.
+* `model`: format-specific builders for RORB and WBNM control vectors, and serialisation helpers that convert the in-memory catchment into strings written by the traveller.
+* `resources`: default templates and static assets used by the model writers.
+
+Supporting modules such as `sf_vector_layer.py` expose a minimal wrapper around OGR vector layers so the builder can consume shapefile geometry consistently.
+
+## Data flow from GIS layers to control files
+
+1. **Load vector data** – Shapefiles for reaches, basins, centroids, and confluences are opened via `SFVectorLayer`, which exposes iterable records with geometry and attributes.
+2. **Build domain objects** – `pyromb.Builder` reads the vector layers, instantiates geometry primitives (`core.geometry`) and attribute classes, and returns lists of reaches, basins, and confluences.
+3. **Assemble the catchment** – A `Catchment` is created from those components. It deduplicates vertices, computes distance-based incidence matrices, and determines upstream/downstream relationships used later by the traveller.
+4. **Generate model output** – A `Traveller` walks the connected catchment to populate model-specific writers (`model` package). For RORB this produces a `vector.catg`; for WBNM a `runfile.wbnm`. Optional plotting uses the connected structure to render diagnostic figures.
+
+Understanding this flow helps target AI-driven changes: geometry or validation fixes generally belong in `core.geometry` or the builder; file-format changes live in `model`; and QGIS integration work happens in the app wrapper and layer adapters.

--- a/documentation/explainers/qgis_integration_plan.md
+++ b/documentation/explainers/qgis_integration_plan.md
@@ -1,0 +1,42 @@
+# QGIS Integration and Dependency Plan
+
+This note captures the changes required to embed Pyromb as a native QGIS Processing algorithm without introducing non-standard dependencies.
+
+## Dependency expectations inside QGIS
+
+* **Python environment** – Recent QGIS releases ship with Python 3.9+ and include GDAL/OGR, PyQt, NumPy, and QGIS core bindings. Third-party packages such as Shapely are not guaranteed to be present and should be avoided unless bundled manually.
+* **Current state** – The repository already limits itself to standard library modules, NumPy, and GDAL/OGR via `osgeo`. A quick audit (`rg "shapely"`) shows no references to Shapely in the current codebase, so future contributions should preserve this dependency footprint.
+
+## Python package installation footprint
+
+Pyromb distributes as a pure Python package with a minimal dependency tree:
+
+* **`gdal`** – Declared in `pyproject.toml` so that the GDAL/OGR Python bindings are available for shapefile access when running outside QGIS. Inside QGIS, the bundled GDAL satisfies this requirement.
+* **Standard library / QGIS built-ins** – The remaining imports come from Python's standard library, NumPy, and QGIS' own modules that ship with the application. No additional PyPI packages are installed by default.
+
+When packaging for QGIS Processing, avoid adding new third-party dependencies unless they are guaranteed to be shipped with QGIS or vendored with the plugin.
+
+## Embedding Pyromb as a Processing provider
+
+1. **Processing entry point** – Wrap the logic in `src/app.py` inside a `QgsProcessingAlgorithm` subclass. The `processAlgorithm` method should:
+   * Accept parameter definitions for the required vector layers (reaches, basins, centroids, confluences) and optional toggles (plotting, output path).
+   * Use `QgsProcessingParameterFeatureSource` to read vector layers directly from the QGIS context, avoiding temporary files.
+   * Instantiate `pyromb.Builder`, `Catchment`, and `Traveller` the same way the helper script does.
+2. **Vector layer abstraction** – Replace `SFVectorLayer` usage with adapters that can consume `QgsFeatureSource` instances. The goal is to reuse existing validation and geometry code, so consider creating an interface that both the shapefile wrapper and a new QGIS wrapper implement.
+3. **Output handling** – The algorithm should write to a processing output (`QgsProcessingOutputFile`) and optionally return the generated vector file path to the model catalog.
+4. **Logging and feedback** – Use the `feedback` object provided by QGIS Processing for progress messages instead of the standard `logging` module when running inside QGIS. Retain standard logging for standalone runs by introducing a thin abstraction or conditional helper.
+
+## Geometry logic amendments
+
+The original plugin required adjustments to geometry handling to work reliably inside QGIS. Further work should focus on:
+
+* **Tolerance-aware matching** – `Catchment._find_vertex_by_coordinates` currently uses a numeric tolerance when matching nodes. Confirm that the tolerance is appropriate for the coordinate precision in QGIS projects and expose it as a configurable parameter if needed.
+* **Projected vs geographic CRS** – Ensure builders operate on projected coordinates (metres) when computing lengths, slopes, or areas. Incorporate CRS validation in the Processing algorithm to warn users when they run the tool in a geographic CRS.
+* **Geometry extraction** – When moving from OGR-based layers to `QgsFeature`, use native geometry accessors (`feature.geometry().asPolyline()` etc.) to avoid relying on Shapely conversion helpers.
+
+## Next steps and open questions
+
+* Define a minimal adapter interface for vector layers so we can plug in both OGR and QGIS data sources without duplicating builder logic.
+* Decide whether plotting should remain part of the Processing algorithm or become a standalone diagnostic tool. Plotting libraries may not be available in all QGIS deployments.
+* Review existing serialisation helpers (`serialise.py`) to ensure they are optional in production builds; they are mainly for testing and may not suit a Processing context.
+* Document user-facing parameter descriptions and default values for the QGIS tool so plugin development can begin immediately after the geometry updates.


### PR DESCRIPTION
## Summary
- add an architecture explainer describing the data flow from shapefiles to model outputs
- document a QGIS-focused integration and dependency plan that avoids non-native libraries and clarifies the package footprint
- provide an AI contributor playbook covering conventions, testing, and open questions
- add an AGENTS.md pointing contributors to the explainers and expectations
- capture review notes comparing the new documentation commit against the previous fork state

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e27f8767e4832eb8ed57bdaa1b2e94